### PR TITLE
chore: align gh actions and dependabot with ecosystem standard

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,3 +15,11 @@ updates:
         package-ecosystem: "github-actions"
         schedule:
             interval: "daily"
+        groups:
+            security-updates:
+                patterns:
+                    - '*'
+                exclude-patterns:
+                    - 'storyblok*'
+                update-types:
+                    - patch

--- a/.github/workflows/dependabot-autoapprove.yml
+++ b/.github/workflows/dependabot-autoapprove.yml
@@ -1,0 +1,28 @@
+name: Dependabot auto-approve
+on: pull_request
+
+permissions:
+    pull-requests: write
+
+jobs:
+    dependabot:
+        runs-on: ubuntu-latest
+        if: github.event.pull_request.user.login == 'dependabot[bot]' && github.repository == 'storyblok/php-content-api-client'
+        steps:
+            - name: Dependabot metadata
+              id: metadata
+              uses: dependabot/fetch-metadata@v2
+              with:
+                  github-token: "${{ secrets.GITHUB_TOKEN }}"
+                  alert-lookup: true
+            - uses: actions/checkout@v4
+            - name: Approve a PR if not already approved
+              run: |
+                  gh pr checkout "$PR_URL" # sets the upstream metadata for `gh pr status`
+                  if [ "$(gh pr status --json reviewDecision -q .currentBranch.reviewDecision)" != "APPROVED" ];
+                  then gh pr review --approve "$PR_URL"
+                  else echo "PR already approved, skipping additional approvals to minimize emails/notification noise.";
+                  fi
+              env:
+                  PR_URL: ${{github.event.pull_request.html_url}}
+                  GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
With this dependabot will create a single PR "security-updates" with multiple patch updates do deps.
Also a new GH Action will automatically approve any dependabot PR so they can be merged without further approvals.