### PR TITLE
Enhancement: Automatic Relation Resolution

### DIFF
--- a/src/Bridge/Faker/Generator.php
+++ b/src/Bridge/Faker/Generator.php
@@ -20,19 +20,20 @@ use Storyblok\Api\Bridge\Faker\Provider\StoryblokProvider;
 /**
  * @author Silas Joisten <silasjoisten@proton.me>
  *
- * @method array assetResponse(array $overrides = [])
- * @method array datasourceDimensionResponse(array $overrides = [])
- * @method array datasourceEntriesResponse(array $overrides = [])
- * @method array datasourceEntryResponse(array $overrides = [])
- * @method array datasourceResponse(array $overrides = [])
- * @method array datasourcesResponse(array $overrides = [])
- * @method array linkAlternateResponse(array $overrides = [])
- * @method array linkResponse(array $overrides = [])
- * @method array linksResponse(array $overrides = [])
- * @method array spaceResponse(array $overrides = [])
- * @method array storiesResponse(array $overrides = [])
- * @method array storyResponse(array $overrides = [])
- * @method array tagsResponse(array $overrides = [])
+ * @method array  assetResponse(array $overrides = [])
+ * @method array  datasourceDimensionResponse(array $overrides = [])
+ * @method array  datasourceEntriesResponse(array $overrides = [])
+ * @method array  datasourceEntryResponse(array $overrides = [])
+ * @method array  datasourceResponse(array $overrides = [])
+ * @method array  datasourcesResponse(array $overrides = [])
+ * @method array  linkAlternateResponse(array $overrides = [])
+ * @method array  linkResponse(array $overrides = [])
+ * @method array  linksResponse(array $overrides = [])
+ * @method string relation()
+ * @method array  spaceResponse(array $overrides = [])
+ * @method array  storiesResponse(array $overrides = [])
+ * @method array  storyResponse(array $overrides = [])
+ * @method array  tagsResponse(array $overrides = [])
  */
 final class Generator extends BaseGenerator
 {

--- a/src/Bridge/Faker/Provider/StoryblokProvider.php
+++ b/src/Bridge/Faker/Provider/StoryblokProvider.php
@@ -503,4 +503,13 @@ final class StoryblokProvider extends BaseProvider
             $overrides,
         );
     }
+
+    public function relation(): string
+    {
+        return \sprintf(
+            '%s.%s',
+            $this->generator->word(),
+            $this->generator->word(),
+        );
+    }
 }

--- a/src/Domain/Value/Resolver/Relation.php
+++ b/src/Domain/Value/Resolver/Relation.php
@@ -25,6 +25,6 @@ final readonly class Relation
         public string $value,
     ) {
         TrimmedNonEmptyString::fromString($value);
-        Assert::contains('.', $value);
+        Assert::contains($value, '.');
     }
 }

--- a/src/Domain/Value/Resolver/Relation.php
+++ b/src/Domain/Value/Resolver/Relation.php
@@ -25,6 +25,6 @@ final readonly class Relation
         public string $value,
     ) {
         TrimmedNonEmptyString::fromString($value);
-        Assert::contains($value, '.');
+        Assert::regex($value, '/^([a-zA-Z].+)\.([a-zA-Z].+)$/');
     }
 }

--- a/src/Domain/Value/Resolver/Relation.php
+++ b/src/Domain/Value/Resolver/Relation.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Domain\Value\Resolver;
+
+use OskarStark\Value\TrimmedNonEmptyString;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
+final readonly class Relation
+{
+    public function __construct(
+        public string $value,
+    ) {
+        TrimmedNonEmptyString::fromString($value);
+        Assert::contains('.', $value);
+    }
+}

--- a/src/Domain/Value/Resolver/RelationCollection.php
+++ b/src/Domain/Value/Resolver/RelationCollection.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Domain\Value\Resolver;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ *
+ * @implements \IteratorAggregate<int, Relation>
+ */
+final class RelationCollection implements \Countable, \IteratorAggregate
+{
+    /**
+     * @var list<Relation>
+     */
+    private array $items = [];
+
+    /**
+     * @param list<Relation> $items
+     */
+    public function __construct(
+        array $items = [],
+    ) {
+        foreach ($items as $item) {
+            $this->add($item);
+        }
+    }
+
+    /**
+     * @return \Traversable<int, Relation>
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->items);
+    }
+
+    public function count(): int
+    {
+        return \count($this->items);
+    }
+
+    public function add(Relation $relation): void
+    {
+        if ($this->has($relation)) {
+            return;
+        }
+
+        $this->items[] = $relation;
+    }
+
+    public function has(Relation $relation): bool
+    {
+        foreach ($this->items as $item) {
+            if ($item->value === $relation->value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function remove(Relation $relation): void
+    {
+        foreach ($this->items as $key => $item) {
+            if ($item->value === $relation->value) {
+                unset($this->items[$key]);
+
+                break;
+            }
+        }
+    }
+
+    public function toString(): string
+    {
+        return implode(',', array_map(static fn (Relation $relation): string => $relation->value, $this->items));
+    }
+}

--- a/src/Request/StoriesRequest.php
+++ b/src/Request/StoriesRequest.php
@@ -87,6 +87,10 @@ final readonly class StoriesRequest
             $array['excluding_ids'] = $this->excludeIds->toString();
         }
 
+        if (null !== $this->withRelations && $this->withRelations->count() > 0) {
+            $array['resolve_relations'] = $this->withRelations->toString();
+        }
+
         if (null !== $this->version) {
             $array['version'] = $this->version->value;
         }

--- a/src/Request/StoriesRequest.php
+++ b/src/Request/StoriesRequest.php
@@ -19,6 +19,7 @@ use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Field\FieldCollection;
 use Storyblok\Api\Domain\Value\Filter\FilterCollection;
 use Storyblok\Api\Domain\Value\IdCollection;
+use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
 use Storyblok\Api\Domain\Value\Tag\TagCollection;
 use Webmozart\Assert\Assert;
 
@@ -38,6 +39,7 @@ final readonly class StoriesRequest
         public ?FieldCollection $excludeFields = null,
         public ?TagCollection $withTags = null,
         public ?IdCollection $excludeIds = null,
+        public ?RelationCollection $withRelations = null,
         public ?Version $version = null,
     ) {
         Assert::stringNotEmpty($language);

--- a/src/Request/StoryRequest.php
+++ b/src/Request/StoryRequest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Storyblok\Api\Request;
 
 use Storyblok\Api\Domain\Value\Dto\Version;
+use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
 use Webmozart\Assert\Assert;
 
 /**
@@ -24,6 +25,7 @@ final readonly class StoryRequest
     public function __construct(
         public string $language = 'default',
         public ?Version $version = null,
+        public ?RelationCollection $withRelations = null,
     ) {
         Assert::stringNotEmpty($language);
     }
@@ -32,6 +34,7 @@ final readonly class StoryRequest
      * @return array{
      *     language: string,
      *     version?: string,
+     *     resolve_relations?: string,
      * }
      */
     public function toArray(): array
@@ -42,6 +45,10 @@ final readonly class StoryRequest
 
         if (null !== $this->version) {
             $array['version'] = $this->version->value;
+        }
+
+        if (null !== $this->withRelations && $this->withRelations->count() > 0) {
+            $array['resolve_relations'] = $this->withRelations->toString();
         }
 
         return $array;

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -21,8 +21,8 @@ interface ResolverInterface
     /**
      * Resolves relations in the target content using the given relations collection.
      *
-     * @param array<string, mixed>             $target The target story content containing UUIDs to resolve.
-     * @param array<int, array<string, mixed>> $relations The target story content containing UUIDs to resolve.
+     * @param array<string, mixed>             $target    the target story content containing UUIDs to resolve
+     * @param array<int, array<string, mixed>> $relations the target story content containing UUIDs to resolve
      *
      * @return array<string, mixed>
      */

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -13,7 +13,18 @@ declare(strict_types=1);
 
 namespace Storyblok\Api\Resolver;
 
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
 interface ResolverInterface
 {
+    /**
+     * Resolves relations in the target content using the given relations collection.
+     *
+     * @param array<string, mixed>             $target The target story content containing UUIDs to resolve.
+     * @param array<int, array<string, mixed>> $relations The target story content containing UUIDs to resolve.
+     *
+     * @return array<string, mixed>
+     */
     public function resolve(array $target, array $relations): array;
 }

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Resolver;
+
+interface ResolverInterface
+{
+    public function resolve(array $target, array $relations): array;
+}

--- a/src/Resolver/StoryResolver.php
+++ b/src/Resolver/StoryResolver.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Resolver;
+
+final readonly class StoryResolver implements ResolverInterface
+{
+    public function resolve(array $target, array $relations): array
+    {
+        //        dd($target, $relations);
+        // TODO: Relation resolving here.
+
+        return $target;
+    }
+}

--- a/src/Resolver/StoryResolver.php
+++ b/src/Resolver/StoryResolver.php
@@ -26,6 +26,7 @@ final readonly class StoryResolver implements ResolverInterface
 
         foreach ($relations as $relation) {
             Assert::keyExists($relation, 'uuid');
+            Assert::uuid($relation['uuid']);
             $relationMap[$relation['uuid']] = $relation;
         }
 

--- a/src/Resolver/StoryResolver.php
+++ b/src/Resolver/StoryResolver.php
@@ -24,10 +24,16 @@ final readonly class StoryResolver implements ResolverInterface
     {
         $relationMap = [];
 
-        foreach ($relations as $relation) {
+        foreach ($relations as $key => $relation) {
             Assert::keyExists($relation, 'uuid');
             Assert::uuid($relation['uuid']);
             $relationMap[$relation['uuid']] = $relation;
+
+            // There is a limit of possible resolvable relations.
+            // @see https://www.storyblok.com/docs/api/content-delivery/v2/stories/retrieve-a-single-story
+            if (50 === $key) {
+                break;
+            }
         }
 
         foreach ($target as &$value) {

--- a/src/Resolver/StoryResolver.php
+++ b/src/Resolver/StoryResolver.php
@@ -13,12 +13,33 @@ declare(strict_types=1);
 
 namespace Storyblok\Api\Resolver;
 
+use Webmozart\Assert\Assert;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
 final readonly class StoryResolver implements ResolverInterface
 {
     public function resolve(array $target, array $relations): array
     {
-        //        dd($target, $relations);
-        // TODO: Relation resolving here.
+        $relationMap = [];
+
+        foreach ($relations as $relation) {
+            Assert::keyExists($relation, 'uuid');
+            $relationMap[$relation['uuid']] = $relation;
+        }
+
+        foreach ($target as &$value) {
+            if (is_string($value) && array_key_exists($value, $relationMap)) {
+                $value = $relationMap[$value];
+
+                continue;
+            }
+
+            if (is_array($value)) {
+                $value = $this->resolve($value, $relations);
+            }
+        }
 
         return $target;
     }

--- a/src/Resolver/StoryResolver.php
+++ b/src/Resolver/StoryResolver.php
@@ -30,13 +30,13 @@ final readonly class StoryResolver implements ResolverInterface
         }
 
         foreach ($target as &$value) {
-            if (is_string($value) && array_key_exists($value, $relationMap)) {
+            if (\is_string($value) && \array_key_exists($value, $relationMap)) {
                 $value = $relationMap[$value];
 
                 continue;
             }
 
-            if (is_array($value)) {
+            if (\is_array($value)) {
                 $value = $this->resolve($value, $relations);
             }
         }

--- a/src/Response/StoriesResponse.php
+++ b/src/Response/StoriesResponse.php
@@ -29,7 +29,7 @@ final readonly class StoriesResponse
     public int $cv;
 
     /**
-     * @var list<string>
+     * @var list<array<string, mixed>>
      */
     public array $rels;
 

--- a/src/Response/StoryResponse.php
+++ b/src/Response/StoryResponse.php
@@ -27,7 +27,7 @@ final readonly class StoryResponse
     public int $cv;
 
     /**
-     * @var list<array<mixed>>
+     * @var list<array<string, mixed>>
      */
     public array $rels;
 

--- a/src/StoriesApi.php
+++ b/src/StoriesApi.php
@@ -15,7 +15,6 @@ namespace Storyblok\Api;
 
 use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Id;
-use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
 use Storyblok\Api\Domain\Value\Total;
 use Storyblok\Api\Domain\Value\Uuid;
 use Storyblok\Api\Request\StoriesRequest;

--- a/src/StoriesApi.php
+++ b/src/StoriesApi.php
@@ -15,6 +15,7 @@ namespace Storyblok\Api;
 
 use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Id;
+use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
 use Storyblok\Api\Domain\Value\Total;
 use Storyblok\Api\Domain\Value\Uuid;
 use Storyblok\Api\Request\StoriesRequest;

--- a/src/StoriesResolvedApi.php
+++ b/src/StoriesResolvedApi.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api;
+
+use Storyblok\Api\Domain\Value\Dto\Version;
+use Storyblok\Api\Domain\Value\Id;
+use Storyblok\Api\Domain\Value\Uuid;
+use Storyblok\Api\Request\StoriesRequest;
+use Storyblok\Api\Resolver\ResolverInterface;
+use Storyblok\Api\Response\StoriesResponse;
+use Storyblok\Api\Response\StoryResponse;
+use Webmozart\Assert\Assert;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
+final readonly class StoriesResolvedApi implements StoriesApiInterface
+{
+    public function __construct(
+        private StoriesApiInterface $storiesApi,
+        private ResolverInterface $resolver,
+    ) {
+    }
+
+    public function all(?StoriesRequest $request = null): StoriesResponse
+    {
+        Assert::notNull($request);
+        Assert::notNull($request->withRelations);
+
+        $response = $this->storiesApi->all($request);
+
+        $stories = [];
+
+        foreach ($response->stories as $story) {
+            $stories[] = $this->resolver->resolve($story, $response->rels);
+        }
+
+        return new StoriesResponse(
+            $response->total,
+            $response->pagination,
+            [
+                'cv' => $response->cv,
+                'rels' => $response->rels,
+                'links' => $response->links,
+                'stories' => $stories,
+            ],
+        );
+    }
+
+    public function allByContentType(string $contentType, ?StoriesRequest $request = null): StoriesResponse
+    {
+        Assert::notNull($request);
+        Assert::notNull($request->withRelations);
+
+        $response = $this->storiesApi->allByContentType($contentType, $request);
+
+        $stories = [];
+
+        foreach ($response->stories as $story) {
+            $stories[] = $this->resolver->resolve($story, $response->rels);
+        }
+
+        return new StoriesResponse(
+            $response->total,
+            $response->pagination,
+            [
+                'cv' => $response->cv,
+                'rels' => $response->rels,
+                'links' => $response->links,
+                'stories' => $stories,
+            ],
+        );
+    }
+
+    public function bySlug(string $slug, string $language = 'default', ?Version $version = null): StoryResponse
+    {
+        $response = $this->storiesApi->bySlug($slug, $language, $version);
+
+        $story = $this->resolver->resolve($response->story, $response->rels);
+
+        return new StoryResponse([
+            'cv' => $response->cv,
+            'rels' => $response->rels,
+            'links' => $response->links,
+            'story' => $story,
+        ]);
+    }
+
+    public function byUuid(Uuid $uuid, string $language = 'default', ?Version $version = null): StoryResponse
+    {
+        $response = $this->storiesApi->byUuid($uuid, $language, $version);
+
+        $story = $this->resolver->resolve($response->story, $response->rels);
+
+        return new StoryResponse([
+            'cv' => $response->cv,
+            'rels' => $response->rels,
+            'links' => $response->links,
+            'story' => $story,
+        ]);
+    }
+
+    public function byId(Id $id, string $language = 'default', ?Version $version = null): StoryResponse
+    {
+        $response = $this->storiesApi->byId($id, $language, $version);
+
+        $story = $this->resolver->resolve($response->story, $response->rels);
+
+        return new StoryResponse([
+            'cv' => $response->cv,
+            'rels' => $response->rels,
+            'links' => $response->links,
+            'story' => $story,
+        ]);
+    }
+}

--- a/src/StoriesResolvedApi.php
+++ b/src/StoriesResolvedApi.php
@@ -35,10 +35,14 @@ final readonly class StoriesResolvedApi implements StoriesApiInterface
 
     public function all(?StoriesRequest $request = null): StoriesResponse
     {
-        Assert::notNull($request);
-        Assert::notNull($request->withRelations);
-
         $response = $this->storiesApi->all($request);
+
+        if (null === $request
+            || null === $request->withRelations
+            || 0 === $request->withRelations->count()
+        ) {
+            return $response;
+        }
 
         $stories = [];
 
@@ -60,10 +64,14 @@ final readonly class StoriesResolvedApi implements StoriesApiInterface
 
     public function allByContentType(string $contentType, ?StoriesRequest $request = null): StoriesResponse
     {
-        Assert::notNull($request);
-        Assert::notNull($request->withRelations);
-
         $response = $this->storiesApi->allByContentType($contentType, $request);
+
+        if (null === $request
+            || null === $request->withRelations
+            || 0 === $request->withRelations->count()
+        ) {
+            return $response;
+        }
 
         $stories = [];
 

--- a/src/StoriesResolvedApi.php
+++ b/src/StoriesResolvedApi.php
@@ -15,6 +15,7 @@ namespace Storyblok\Api;
 
 use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Id;
+use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
 use Storyblok\Api\Domain\Value\Uuid;
 use Storyblok\Api\Request\StoriesRequest;
 use Storyblok\Api\Resolver\ResolverInterface;
@@ -91,9 +92,9 @@ final readonly class StoriesResolvedApi implements StoriesApiInterface
         );
     }
 
-    public function bySlug(string $slug, string $language = 'default', ?Version $version = null): StoryResponse
+    public function bySlug(string $slug, string $language = 'default', ?Version $version = null, ?RelationCollection $withRelations = null): StoryResponse
     {
-        $response = $this->storiesApi->bySlug($slug, $language, $version);
+        $response = $this->storiesApi->bySlug($slug, $language, $version, $withRelations);
 
         $story = $this->resolver->resolve($response->story, $response->rels);
 
@@ -105,9 +106,9 @@ final readonly class StoriesResolvedApi implements StoriesApiInterface
         ]);
     }
 
-    public function byUuid(Uuid $uuid, string $language = 'default', ?Version $version = null): StoryResponse
+    public function byUuid(Uuid $uuid, string $language = 'default', ?Version $version = null, ?RelationCollection $withRelations = null): StoryResponse
     {
-        $response = $this->storiesApi->byUuid($uuid, $language, $version);
+        $response = $this->storiesApi->byUuid($uuid, $language, $version, $withRelations);
 
         $story = $this->resolver->resolve($response->story, $response->rels);
 
@@ -119,9 +120,9 @@ final readonly class StoriesResolvedApi implements StoriesApiInterface
         ]);
     }
 
-    public function byId(Id $id, string $language = 'default', ?Version $version = null): StoryResponse
+    public function byId(Id $id, string $language = 'default', ?Version $version = null, ?RelationCollection $withRelations = null): StoryResponse
     {
-        $response = $this->storiesApi->byId($id, $language, $version);
+        $response = $this->storiesApi->byId($id, $language, $version, $withRelations);
 
         $story = $this->resolver->resolve($response->story, $response->rels);
 

--- a/src/StoriesResolvedApi.php
+++ b/src/StoriesResolvedApi.php
@@ -21,7 +21,6 @@ use Storyblok\Api\Request\StoriesRequest;
 use Storyblok\Api\Resolver\ResolverInterface;
 use Storyblok\Api\Response\StoriesResponse;
 use Storyblok\Api\Response\StoryResponse;
-use Webmozart\Assert\Assert;
 
 /**
  * @author Silas Joisten <silasjoisten@proton.me>

--- a/src/StoriesResolvedApi.php
+++ b/src/StoriesResolvedApi.php
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace Storyblok\Api;
 
-use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Id;
-use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
 use Storyblok\Api\Domain\Value\Uuid;
 use Storyblok\Api\Request\StoriesRequest;
+use Storyblok\Api\Request\StoryRequest;
 use Storyblok\Api\Resolver\ResolverInterface;
 use Storyblok\Api\Response\StoriesResponse;
 use Storyblok\Api\Response\StoryResponse;
@@ -91,9 +90,9 @@ final readonly class StoriesResolvedApi implements StoriesApiInterface
         );
     }
 
-    public function bySlug(string $slug, string $language = 'default', ?Version $version = null, ?RelationCollection $withRelations = null): StoryResponse
+    public function bySlug(string $slug, ?StoryRequest $request = null): StoryResponse
     {
-        $response = $this->storiesApi->bySlug($slug, $language, $version, $withRelations);
+        $response = $this->storiesApi->bySlug($slug, $request);
 
         $story = $this->resolver->resolve($response->story, $response->rels);
 
@@ -105,9 +104,9 @@ final readonly class StoriesResolvedApi implements StoriesApiInterface
         ]);
     }
 
-    public function byUuid(Uuid $uuid, string $language = 'default', ?Version $version = null, ?RelationCollection $withRelations = null): StoryResponse
+    public function byUuid(Uuid $uuid, ?StoryRequest $request = null): StoryResponse
     {
-        $response = $this->storiesApi->byUuid($uuid, $language, $version, $withRelations);
+        $response = $this->storiesApi->byUuid($uuid, $request);
 
         $story = $this->resolver->resolve($response->story, $response->rels);
 
@@ -119,9 +118,9 @@ final readonly class StoriesResolvedApi implements StoriesApiInterface
         ]);
     }
 
-    public function byId(Id $id, string $language = 'default', ?Version $version = null, ?RelationCollection $withRelations = null): StoryResponse
+    public function byId(Id $id, ?StoryRequest $request = null): StoryResponse
     {
-        $response = $this->storiesApi->byId($id, $language, $version, $withRelations);
+        $response = $this->storiesApi->byId($id, $request);
 
         $story = $this->resolver->resolve($response->story, $response->rels);
 

--- a/tests/Unit/Domain/Value/Resolver/RelationCollectionTest.php
+++ b/tests/Unit/Domain/Value/Resolver/RelationCollectionTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Tests\Unit\Domain\Value\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Api\Domain\Value\Resolver\Relation;
+use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
+use Storyblok\Api\Tests\Util\FakerTrait;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
+final class RelationCollectionTest extends TestCase
+{
+    use FakerTrait;
+
+    /**
+     * @test
+     */
+    public function add(): void
+    {
+        $faker = self::faker();
+
+        $collection = new RelationCollection();
+        self::assertEmpty($collection);
+
+        $collection->add(new Relation($faker->relation()));
+        self::assertCount(1, $collection);
+    }
+
+    /**
+     * @test
+     */
+    public function remove(): void
+    {
+        $faker = self::faker();
+
+        $relation = new Relation($faker->relation());
+
+        $collection = new RelationCollection([$relation]);
+        self::assertCount(1, $collection);
+
+        $collection->remove($relation);
+        self::assertEmpty($collection);
+    }
+
+    /**
+     * @test
+     */
+    public function hasReturnsTrue(): void
+    {
+        $faker = self::faker();
+
+        $relation = new Relation($faker->relation());
+
+        $collection = new RelationCollection([$relation, new Relation($faker->relation())]);
+
+        self::assertTrue($collection->has($relation));
+    }
+
+    /**
+     * @test
+     */
+    public function hasReturnsFalse(): void
+    {
+        $faker = self::faker();
+
+        $collection = new RelationCollection([new Relation($faker->relation())]);
+
+        self::assertFalse($collection->has(new Relation($faker->relation())));
+    }
+
+    /**
+     * @test
+     */
+    public function isCountable(): void
+    {
+        $faker = self::faker();
+
+        $relation = new Relation($faker->relation());
+
+        $collection = new RelationCollection([$relation]);
+
+        self::assertSame(1, $collection->count());
+    }
+
+    /**
+     * @test
+     */
+    public function toStringMethod(): void
+    {
+        $faker = self::faker();
+
+        $relations = [
+            new Relation($relation1 = $faker->relation()),
+            new Relation($relation2 = $faker->relation()),
+            new Relation($relation3 = $faker->relation()),
+        ];
+
+        $collection = new RelationCollection($relations);
+
+        self::assertSame(implode(',', [$relation1, $relation2, $relation3]), $collection->toString());
+    }
+
+    /**
+     * @test
+     */
+    public function getIterator(): void
+    {
+        $faker = self::faker();
+
+        $relations = [
+            new Relation($faker->relation()),
+            new Relation($faker->relation()),
+        ];
+
+        self::assertInstanceOf(\ArrayIterator::class, (new RelationCollection($relations))->getIterator());
+    }
+}

--- a/tests/Unit/Domain/Value/Resolver/RelationTest.php
+++ b/tests/Unit/Domain/Value/Resolver/RelationTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Tests\Unit\Domain\Value\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Api\Domain\Value\Resolver\Relation;
+use Storyblok\Api\Tests\Util\FakerTrait;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
+final class RelationTest extends TestCase
+{
+    use FakerTrait;
+
+    /**
+     * @test
+     */
+    public function value(): void
+    {
+        $value = self::faker()->relation();
+
+        self::assertSame($value, (new Relation($value))->value);
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::arbitrary()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::blank()
+     * @dataProvider \Ergebnis\DataProvider\StringProvider::empty()
+     */
+    public function valueInvalid(string $value): void
+    {
+        self::expectException(\InvalidArgumentException::class);
+
+        new Relation($value);
+    }
+}

--- a/tests/Unit/Request/StoriesRequestTest.php
+++ b/tests/Unit/Request/StoriesRequestTest.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Tests\Unit\Request;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Api\Domain\Value\Dto\Direction;
+use Storyblok\Api\Domain\Value\Dto\SortBy;
+use Storyblok\Api\Domain\Value\Dto\Version;
+use Storyblok\Api\Domain\Value\Field\Field;
+use Storyblok\Api\Domain\Value\Field\FieldCollection;
+use Storyblok\Api\Domain\Value\Filter\FilterCollection;
+use Storyblok\Api\Domain\Value\Filter\Filters\InFilter;
+use Storyblok\Api\Domain\Value\Id;
+use Storyblok\Api\Domain\Value\IdCollection;
+use Storyblok\Api\Domain\Value\Resolver\Relation;
+use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
+use Storyblok\Api\Domain\Value\Tag\Tag;
+use Storyblok\Api\Domain\Value\Tag\TagCollection;
+use Storyblok\Api\Request\StoriesRequest;
+use Storyblok\Api\Tests\Util\FakerTrait;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
+final class StoriesRequestTest extends TestCase
+{
+    use FakerTrait;
+
+    /**
+     * @test
+     */
+    public function toArrayWithDefaults(): void
+    {
+        $request = new StoriesRequest();
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+        ], $request->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function toArrayWithSortBy(): void
+    {
+        $request = new StoriesRequest(
+            sortBy: new SortBy('name', Direction::Asc),
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'sort_by' => 'name:asc',
+        ], $request->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function toArrayWithFilters(): void
+    {
+        $request = new StoriesRequest(
+            filters: new FilterCollection([
+                new InFilter('name', ['foo', 'bar']),
+            ]),
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'filter_query' => [
+                'name' => [
+                    'in' => 'foo,bar',
+                ],
+            ],
+        ], $request->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function toArrayWithExcludeFields(): void
+    {
+        $request = new StoriesRequest(
+            excludeFields: new FieldCollection([
+                new Field('body'),
+                new Field('content'),
+            ]),
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'excluding_fields' => 'body,content',
+        ], $request->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function toArrayWithTags(): void
+    {
+        $request = new StoriesRequest(
+            withTags: new TagCollection([
+                new Tag('foo'),
+                new Tag('bar'),
+            ]),
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'with_tag' => 'foo,bar',
+        ], $request->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function toArrayWithExcludeIds(): void
+    {
+        $request = new StoriesRequest(
+            excludeIds: new IdCollection([
+                new Id(1),
+            ]),
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'excluding_ids' => '1',
+        ], $request->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function toArrayWithRelations(): void
+    {
+        $request = new StoriesRequest(
+            withRelations: new RelationCollection([
+                new Relation('blog_post.category'),
+            ]),
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'resolve_relations' => 'blog_post.category',
+        ], $request->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function toArrayWithVersion(): void
+    {
+        $request = new StoriesRequest(
+            version: $version = Version::Published,
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'version' => $version->value,
+        ], $request->toArray());
+    }
+}

--- a/tests/Unit/Request/StoryRequestTest.php
+++ b/tests/Unit/Request/StoryRequestTest.php
@@ -15,6 +15,8 @@ namespace Storyblok\Api\Tests\Unit\Request;
 
 use PHPUnit\Framework\TestCase;
 use Storyblok\Api\Domain\Value\Dto\Version;
+use Storyblok\Api\Domain\Value\Resolver\Relation;
+use Storyblok\Api\Domain\Value\Resolver\RelationCollection;
 use Storyblok\Api\Request\StoryRequest;
 use Storyblok\Api\Tests\Util\FakerTrait;
 
@@ -65,6 +67,24 @@ final class StoryRequestTest extends TestCase
         self::assertSame([
             'language' => 'default',
             'version' => $version->value,
+        ], $request->toArray());
+    }
+
+    /**
+     * @test
+     */
+    public function toArrayWithRelations(): void
+    {
+        $request = new StoryRequest(
+            withRelations: new RelationCollection([
+                new Relation('root.relation'),
+                new Relation('root.another_relation'),
+            ]),
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'resolve_relations' => 'root.relation,root.another_relation',
         ], $request->toArray());
     }
 }

--- a/tests/Unit/Resolver/StoryResolverTest.php
+++ b/tests/Unit/Resolver/StoryResolverTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of Storyblok-Api.
+ *
+ * (c) SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Tests\Unit\Resolver;
+
+use PHPUnit\Framework\TestCase;
+use Storyblok\Api\Resolver\StoryResolver;
+use Storyblok\Api\Tests\Util\FakerTrait;
+
+/**
+ * @author Silas Joisten <silasjoisten@proton.me>
+ */
+final class StoryResolverTest extends TestCase
+{
+    use FakerTrait;
+
+    /**
+     * @test
+     */
+    public function resolve(): void
+    {
+        $resolver = new StoryResolver();
+
+        $faker = self::faker();
+
+        $story = [
+            'name' => $faker->word(),
+            'content' => [
+                'uuid' => $faker->uuid(),
+                'reference' => $referenceUuid = $faker->uuid(),
+                'some_field' => $faker->word(),
+            ],
+        ];
+
+        $references = [
+            $reference = [
+                'uuid' => $referenceUuid,
+                'name' => $faker->word(),
+                'another_field' => $faker->sentence(),
+            ],
+        ];
+
+        $expected = $story;
+        $expected['content']['reference'] = $reference;
+
+        self::assertSame($expected, $resolver->resolve($story, $references));
+    }
+
+    /**
+     * @test
+     */
+    public function resolveWithComplexStructure(): void
+    {
+        $resolver = new StoryResolver();
+
+        $faker = self::faker();
+
+        $story = [
+            'name' => $faker->word(),
+            'content' => [
+                'uuid' => $faker->uuid(),
+                'references' => [
+                    $referenceUuid1 = $faker->uuid(),
+                    $referenceUuid2 = $faker->uuid(),
+                    $referenceUuid3 = $faker->uuid(),
+                    $referenceUuid4 = $faker->uuid(),
+                ],
+                'blocks' => [
+                    [
+                        'uuid' => $faker->uuid(),
+                        'type' => 'card',
+                        'block' => [
+                            'uuid' => $faker->uuid(),
+                            'type' => 'button',
+                            'some_field' => $referenceUuid5 = $faker->uuid(),
+                        ],
+                    ],
+                ],
+                'some_field' => $faker->word(),
+            ],
+        ];
+
+        $references = [
+            [
+                'uuid' => $referenceUuid1,
+                'name' => $faker->word(),
+                'another_field' => $faker->sentence(),
+            ],
+            [
+                'uuid' => $referenceUuid2,
+                'name' => $faker->word(),
+                'another_field' => $faker->sentence(),
+            ],
+            [
+                'uuid' => $referenceUuid3,
+                'name' => $faker->word(),
+                'another_field' => $faker->sentence(),
+            ],
+            [
+                'uuid' => $referenceUuid4,
+                'name' => $faker->word(),
+                'another_field' => $faker->sentence(),
+            ],
+            [
+                'uuid' => $referenceUuid5,
+                'name' => $faker->word(),
+                'price' => $faker->randomNumber(),
+            ],
+        ];
+
+        $expected = $story;
+        $expected['content']['references'] = [$references[0], $references[1], $references[2], $references[3]];
+        $expected['content']['blocks'][0]['block']['some_field'] = $references[4];
+
+        self::assertSame($expected, $resolver->resolve($story, $references));
+    }
+}

--- a/tests/Unit/Resolver/StoryResolverTest.php
+++ b/tests/Unit/Resolver/StoryResolverTest.php
@@ -59,6 +59,46 @@ final class StoryResolverTest extends TestCase
     /**
      * @test
      */
+    public function resolveThrowsExceptionWhenUuidKeyDoesNotExist(): void
+    {
+        $resolver = new StoryResolver();
+
+        $faker = self::faker();
+
+        $reference = [
+            'id' => $faker->uuid(),
+            'name' => $faker->word(),
+            'another_field' => $faker->sentence(),
+        ];
+
+        self::expectException(\InvalidArgumentException::class);
+
+        $resolver->resolve(['name' => $faker->word()], [$reference]);
+    }
+
+    /**
+     * @test
+     */
+    public function resolveThrowsExceptionWhenUuidKeyContainsNoValidUuid(): void
+    {
+        $resolver = new StoryResolver();
+
+        $faker = self::faker();
+
+        $reference = [
+            'uuid' => $faker->word(),
+            'name' => $faker->word(),
+            'another_field' => $faker->sentence(),
+        ];
+
+        self::expectException(\InvalidArgumentException::class);
+
+        $resolver->resolve(['name' => $faker->word()], [$reference]);
+    }
+
+    /**
+     * @test
+     */
     public function resolveWithComplexStructure(): void
     {
         $resolver = new StoryResolver();


### PR DESCRIPTION
This pull request introduces a proof of concept for automatically resolving relations within the Stories API. Instead of using the StoriesApi directly, users will now interact with the StoriesResolvedApi to benefit from automatic relation resolution.

Example Usage:

```php
use Storyblok\Api\StoriesApi;
use Storyblok\Api\StoryblokClient;
use Storyblok\Api\Resolver\StoryResolver;
use Storyblok\Api\Domain\Value\Resolver\Relation;
use Storyblok\Api\Domain\Value\Resolver\RelationCollection;

$resolver = new StoryResolver();
$client = new StoryblokClient(/* ... */);
$storiesApi = new StoriesApi($client);

$storiesApi = new StoriesResolvedApi($storiesApi, $resolver);
$response = $storiesApi->all(withRelations: new RelationCollection([
    new Relation('article.author'),
    new Relation('article.category'),
]));
```

**Key Details:**
- The StoriesResolvedApi class wraps the existing StoriesApi to provide additional functionality for resolving relations automatically.
- Decorator Pattern: The implementation uses the decorator pattern to extend the StoriesApi functionality without modifying the original API class. The new class is injected with the existing StoriesApi client, ensuring no redundancy in the code.

**Why This Approach?**
- The decorator pattern allows us to add the relation resolution functionality while keeping the existing API intact.
- The change simplifies relation handling for users, as they don’t need to manually resolve relations anymore.

Looking forward to your feedback! 😊