### PR TITLE
Fix: Fix `translated_slug` causes exception

### DIFF
--- a/src/Domain/Value/LinkAlternate.php
+++ b/src/Domain/Value/LinkAlternate.php
@@ -46,8 +46,13 @@ final readonly class LinkAlternate
         Assert::keyExists($values, 'path');
         $this->path = TrimmedNonEmptyString::fromString($values['path'])->toString();
 
-        Assert::keyExists($values, 'translated_slug');
-        $this->slug = TrimmedNonEmptyString::fromString($values['translated_slug'])->toString();
+        $slug = null;
+
+        if (\array_key_exists('translated_slug', $values)) {
+            $slug = TrimmedNonEmptyString::fromString($values['translated_slug'])->toString();
+        }
+
+        $this->slug = $slug ?? $this->path;
 
         Assert::keyExists($values, 'published');
         $this->published = true === $values['published'];

--- a/tests/Unit/Domain/Value/LinkAlternateTest.php
+++ b/tests/Unit/Domain/Value/LinkAlternateTest.php
@@ -129,14 +129,15 @@ final class LinkAlternateTest extends TestCase
     /**
      * @test
      */
-    public function slugKeyMustExist(): void
+    public function slugKeyHasFallback(): void
     {
-        $values = self::faker()->linkAlternateResponse();
+        $values = self::faker()->linkAlternateResponse([
+            'path' => $path = self::faker()->slug(),
+        ]);
+
         unset($values['translated_slug']);
 
-        self::expectException(\InvalidArgumentException::class);
-
-        new LinkAlternate($values);
+        self::assertSame($path, (new LinkAlternate($values))->slug);
     }
 
     /**


### PR DESCRIPTION
This PR is about fixing an `\InvalidArgumentException` thrown when you enabled the Individual publishing of stories.

![CleanShot 2025-01-28 at 09 46 52](https://github.com/user-attachments/assets/cf8a200c-9f3c-4609-a469-5f8c79281bd0)

This wont cause any BC breaks because `slug`'s fallback value is `path`