### PR TITLE
Allow `strings` or `int` in Collections

### DIFF
--- a/src/Domain/Value/Field/FieldCollection.php
+++ b/src/Domain/Value/Field/FieldCollection.php
@@ -26,12 +26,16 @@ final class FieldCollection implements \Countable, \IteratorAggregate
     private array $items = [];
 
     /**
-     * @param list<Field> $items
+     * @param list<Field|string> $items
      */
     public function __construct(
         array $items = [],
     ) {
         foreach ($items as $item) {
+            if (\is_string($item)) {
+                $item = new Field($item);
+            }
+
             $this->add($item);
         }
     }

--- a/src/Domain/Value/IdCollection.php
+++ b/src/Domain/Value/IdCollection.php
@@ -26,12 +26,16 @@ final class IdCollection implements \Countable, \IteratorAggregate
     private array $items = [];
 
     /**
-     * @param list<Id> $items
+     * @param list<Id|int> $items
      */
     public function __construct(
         array $items = [],
     ) {
         foreach ($items as $item) {
+            if (\is_int($item)) {
+                $item = new Id($item);
+            }
+
             $this->add($item);
         }
     }

--- a/src/Domain/Value/Resolver/RelationCollection.php
+++ b/src/Domain/Value/Resolver/RelationCollection.php
@@ -26,12 +26,16 @@ final class RelationCollection implements \Countable, \IteratorAggregate
     private array $items = [];
 
     /**
-     * @param list<Relation> $items
+     * @param list<Relation|string> $items
      */
     public function __construct(
         array $items = [],
     ) {
         foreach ($items as $item) {
+            if (\is_string($item)) {
+                $item = new Relation($item);
+            }
+
             $this->add($item);
         }
     }

--- a/src/Domain/Value/Tag/TagCollection.php
+++ b/src/Domain/Value/Tag/TagCollection.php
@@ -26,12 +26,16 @@ final class TagCollection implements \Countable, \IteratorAggregate
     private array $items = [];
 
     /**
-     * @param list<Tag> $items
+     * @param list<string|Tag> $items
      */
     public function __construct(
         array $items = [],
     ) {
         foreach ($items as $item) {
+            if (\is_string($item)) {
+                $item = new Tag($item);
+            }
+
             $this->add($item);
         }
     }

--- a/tests/Unit/Domain/Value/Field/FieldCollectionTest.php
+++ b/tests/Unit/Domain/Value/Field/FieldCollectionTest.php
@@ -28,6 +28,18 @@ final class FieldCollectionTest extends TestCase
     /**
      * @test
      */
+    public function constructWithString(): void
+    {
+        $faker = self::faker();
+        $collection = new FieldCollection([$faker->word(), $faker->word()]);
+
+        self::assertCount(2, $collection);
+        self::assertContainsOnlyInstancesOf(Field::class, $collection);
+    }
+
+    /**
+     * @test
+     */
     public function add(): void
     {
         $faker = self::faker();

--- a/tests/Unit/Domain/Value/IdCollectionTest.php
+++ b/tests/Unit/Domain/Value/IdCollectionTest.php
@@ -28,6 +28,18 @@ final class IdCollectionTest extends TestCase
     /**
      * @test
      */
+    public function constructWithString(): void
+    {
+        $faker = self::faker();
+        $collection = new IdCollection([$faker->numberBetween(1), $faker->numberBetween(1)]);
+
+        self::assertCount(2, $collection);
+        self::assertContainsOnlyInstancesOf(Id::class, $collection);
+    }
+
+    /**
+     * @test
+     */
     public function add(): void
     {
         $faker = self::faker();

--- a/tests/Unit/Domain/Value/Resolver/RelationCollectionTest.php
+++ b/tests/Unit/Domain/Value/Resolver/RelationCollectionTest.php
@@ -28,6 +28,18 @@ final class RelationCollectionTest extends TestCase
     /**
      * @test
      */
+    public function constructWithString(): void
+    {
+        $faker = self::faker();
+        $collection = new RelationCollection([$faker->relation(), $faker->relation()]);
+
+        self::assertCount(2, $collection);
+        self::assertContainsOnlyInstancesOf(Relation::class, $collection);
+    }
+
+    /**
+     * @test
+     */
     public function add(): void
     {
         $faker = self::faker();

--- a/tests/Unit/Domain/Value/Tag/TagCollectionTest.php
+++ b/tests/Unit/Domain/Value/Tag/TagCollectionTest.php
@@ -28,6 +28,18 @@ final class TagCollectionTest extends TestCase
     /**
      * @test
      */
+    public function constructWithString(): void
+    {
+        $faker = self::faker();
+        $collection = new TagCollection([$faker->word(), $faker->word()]);
+
+        self::assertCount(2, $collection);
+        self::assertContainsOnlyInstancesOf(Tag::class, $collection);
+    }
+
+    /**
+     * @test
+     */
     public function add(): void
     {
         $faker = self::faker();


### PR DESCRIPTION
This PR improves the DX. It allows us to use the collection with strings or the value object e.g.

```php
new FieldCollection([
    'author',
    'text',
]);
```
Internally its automatically converted to a list of value objects.

or the classic way

```php
new FieldCollection([
    new Field('author'),
    new Field('text'),
]);
```