### PR TITLE
add regex argument to `string()` & `nullOrString()`

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -193,6 +193,18 @@ parameters:
 			path: tests/Unit/Util/ValueObjectTraitTest.php
 
 		-
+			message: '#^Parameter \$regex of static method class@anonymous/tests/Unit/Util/ValueObjectTraitTest\.php\:1133\:\:nullOrString\(\) expects non\-empty\-string\|null, '''' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Unit/Util/ValueObjectTraitTest.php
+
+		-
+			message: '#^Parameter \$regex of static method class@anonymous/tests/Unit/Util/ValueObjectTraitTest\.php\:1243\:\:string\(\) expects non\-empty\-string\|null, '''' given\.$#'
+			identifier: argument.type
+			count: 1
+			path: tests/Unit/Util/ValueObjectTraitTest.php
+
+		-
 			message: '#^Unable to resolve the template type T in call to method static method class@anonymous/tests/Unit/Util/ValueObjectTraitTest\.php\:332\:\:enum\(\)$#'
 			identifier: argument.templateType
 			count: 1

--- a/src/Util/ValueObjectTrait.php
+++ b/src/Util/ValueObjectTrait.php
@@ -362,10 +362,11 @@ trait ValueObjectTrait
     /**
      * Returns null if the value is not set or a trimmed non-empty string.
      *
-     * @param array<mixed>     $values
-     * @param non-empty-string $key
+     * @param array<mixed>          $values
+     * @param non-empty-string      $key
+     * @param null|non-empty-string $regex
      */
-    final protected static function nullOrString(array $values, string $key, ?int $maxLength = null): ?string
+    final protected static function nullOrString(array $values, string $key, ?int $maxLength = null, ?string $regex = null): ?string
     {
         if (!\array_key_exists($key, $values)) {
             return null;
@@ -374,6 +375,11 @@ trait ValueObjectTrait
         if (null !== $maxLength) {
             Assert::greaterThan($maxLength, 0);
             Assert::maxLength($values[$key], $maxLength);
+        }
+
+        if (null !== $regex) {
+            Assert::stringNotEmpty($regex);
+            Assert::regex($values[$key], $regex);
         }
 
         try {
@@ -386,15 +392,21 @@ trait ValueObjectTrait
     /**
      * Returns a trimmed non-empty string.
      *
-     * @param array<mixed>     $values
-     * @param non-empty-string $key
+     * @param array<mixed>          $values
+     * @param non-empty-string      $key
+     * @param null|non-empty-string $regex
      */
-    final protected static function string(array $values, string $key, ?int $maxLength = null): string
+    final protected static function string(array $values, string $key, ?int $maxLength = null, ?string $regex = null): string
     {
         Assert::keyExists($values, $key);
 
         if (null !== $maxLength) {
             Assert::maxLength($values[$key], $maxLength);
+        }
+
+        if (null !== $regex) {
+            Assert::stringNotEmpty($regex);
+            Assert::regex($values[$key], $regex);
         }
 
         return TrimmedNonEmptyString::fromString($values[$key])->toString();

--- a/tests/Unit/Util/ValueObjectTraitTest.php
+++ b/tests/Unit/Util/ValueObjectTraitTest.php
@@ -1114,6 +1114,36 @@ final class ValueObjectTraitTest extends TestCase
     }
 
     #[Test]
+    public function nullOrStringWithRegex(): void
+    {
+        $class = new class() {
+            use ValueObjectTrait {
+                ValueObjectTrait::nullOrString as public;
+            }
+        };
+
+        $values = ['key' => 'hello-world'];
+
+        self::assertSame('hello-world', $class::nullOrString($values, 'key', regex: '/^hello-world$/'));
+    }
+
+    #[Test]
+    public function nullOrStringThrowsExceptionWhenRegexEmpty(): void
+    {
+        $class = new class() {
+            use ValueObjectTrait {
+                ValueObjectTrait::nullOrString as public;
+            }
+        };
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $values = ['key' => 'hello-world'];
+
+        $class::nullOrString($values, 'key', regex: '');
+    }
+
+    #[Test]
     public function string(): void
     {
         $class = new class() {
@@ -1175,6 +1205,36 @@ final class ValueObjectTraitTest extends TestCase
         $this->expectException(\InvalidArgumentException::class);
 
         $class::string($values, 'key', 5);
+    }
+
+    #[Test]
+    public function stringWithRegex(): void
+    {
+        $class = new class() {
+            use ValueObjectTrait {
+                ValueObjectTrait::string as public;
+            }
+        };
+
+        $values = ['key' => 'hello-world'];
+
+        self::assertSame('hello-world', $class::string($values, 'key', regex: '/^hello-world$/'));
+    }
+
+    #[Test]
+    public function stringThrowsExceptionWhenRegexEmpty(): void
+    {
+        $class = new class() {
+            use ValueObjectTrait {
+                ValueObjectTrait::string as public;
+            }
+        };
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $values = ['key' => 'hello-world'];
+
+        $class::string($values, 'key', regex: '');
     }
 
     #[Test]

--- a/tests/Unit/Util/ValueObjectTraitTest.php
+++ b/tests/Unit/Util/ValueObjectTraitTest.php
@@ -1136,11 +1136,27 @@ final class ValueObjectTraitTest extends TestCase
             }
         };
 
-        $this->expectException(\InvalidArgumentException::class);
-
         $values = ['key' => 'hello-world'];
 
+        $this->expectException(\InvalidArgumentException::class);
+
         $class::nullOrString($values, 'key', regex: '');
+    }
+
+    #[Test]
+    public function nullOrStringThrowsExceptionWhenRegexNotMatch(): void
+    {
+        $class = new class() {
+            use ValueObjectTrait {
+                ValueObjectTrait::nullOrString as public;
+            }
+        };
+
+        $values = ['key' => 'not-matching'];
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $class::nullOrString($values, 'key', regex: '/^hello-world$/');
     }
 
     #[Test]
@@ -1235,6 +1251,22 @@ final class ValueObjectTraitTest extends TestCase
         $values = ['key' => 'hello-world'];
 
         $class::string($values, 'key', regex: '');
+    }
+
+    #[Test]
+    public function stringThrowsExceptionWhenRegexNotMatch(): void
+    {
+        $class = new class() {
+            use ValueObjectTrait {
+                ValueObjectTrait::string as public;
+            }
+        };
+
+        $values = ['key' => 'not-matching'];
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $class::string($values, 'key', regex: '/^hello-world$/');
     }
 
     #[Test]


### PR DESCRIPTION
**Pull Request Description**

This PR adds an optional `$regex` parameter to the methods: `ValueObjectTrait::nullOrString`  & `ValueObjectTrait::string` .

**Changes:**
- The `string` method now accepts an optional `?string $regex` parameter.
- If `regex` is set, the value is validated against the given regex.
- Corresponding unit tests ensures that an `\InvalidArgumentException` is thrown when regex is empty or the value not matches the expression.

**Motivation:**
StoryBlok provides an regex validation for string fields.