### PR TITLE
feat(trait): Validate for `TrimmedNonEmptyString` on `regex` argument

### DIFF
--- a/src/Util/ValueObjectTrait.php
+++ b/src/Util/ValueObjectTrait.php
@@ -378,7 +378,7 @@ trait ValueObjectTrait
         }
 
         if (null !== $regex) {
-            TrimmedNonEmptyString::fromString($regex)->toString();
+            TrimmedNonEmptyString::fromString($regex);
             Assert::regex($values[$key], $regex);
         }
 
@@ -405,7 +405,7 @@ trait ValueObjectTrait
         }
 
         if (null !== $regex) {
-            TrimmedNonEmptyString::fromString($regex)->toString();
+            TrimmedNonEmptyString::fromString($regex);
             Assert::regex($values[$key], $regex);
         }
 

--- a/src/Util/ValueObjectTrait.php
+++ b/src/Util/ValueObjectTrait.php
@@ -378,8 +378,7 @@ trait ValueObjectTrait
         }
 
         if (null !== $regex) {
-            Assert::stringNotEmpty($regex);
-            Assert::regex($values[$key], $regex);
+            Assert::regex($values[$key], TrimmedNonEmptyString::fromString($regex)->toString());
         }
 
         try {
@@ -405,8 +404,7 @@ trait ValueObjectTrait
         }
 
         if (null !== $regex) {
-            Assert::stringNotEmpty($regex);
-            Assert::regex($values[$key], $regex);
+            Assert::regex($values[$key], TrimmedNonEmptyString::fromString($regex)->toString());
         }
 
         return TrimmedNonEmptyString::fromString($values[$key])->toString();

--- a/src/Util/ValueObjectTrait.php
+++ b/src/Util/ValueObjectTrait.php
@@ -378,7 +378,8 @@ trait ValueObjectTrait
         }
 
         if (null !== $regex) {
-            Assert::regex($values[$key], TrimmedNonEmptyString::fromString($regex)->toString());
+            TrimmedNonEmptyString::fromString($regex)->toString();
+            Assert::regex($values[$key], $regex);
         }
 
         try {
@@ -404,7 +405,8 @@ trait ValueObjectTrait
         }
 
         if (null !== $regex) {
-            Assert::regex($values[$key], TrimmedNonEmptyString::fromString($regex)->toString());
+            TrimmedNonEmptyString::fromString($regex)->toString();
+            Assert::regex($values[$key], $regex);
         }
 
         return TrimmedNonEmptyString::fromString($values[$key])->toString();


### PR DESCRIPTION
follows
- #59 