### PR TITLE
fix: add exception message for invalid `path` value

### DIFF
--- a/src/Domain/Value/Link.php
+++ b/src/Domain/Value/Link.php
@@ -45,7 +45,7 @@ final readonly class Link
     public function __construct(array $values)
     {
         Assert::keyExists($values, 'id');
-        Assert::integer($values['id']);
+        Assert::integer($values['id'], 'The value of the "id" key must be an integer. Got: %s');
         $this->id = new Id($values['id']);
 
         Assert::keyExists($values, 'parent_id');
@@ -64,24 +64,24 @@ final readonly class Link
         $this->uuid = new Uuid($values['uuid']);
 
         Assert::keyExists($values, 'name');
-        $this->name = TrimmedNonEmptyString::fromString($values['name'], 'The value of key "name" must be an trimmed non empty string')->toString();
+        $this->name = TrimmedNonEmptyString::fromString($values['name'], 'The value of the "name" key must be a non-empty, trimmed string. Got: %s')->toString();
 
         Assert::keyExists($values, 'slug');
-        $this->slug = TrimmedNonEmptyString::fromString($values['slug'], 'The value of key "slug" must be an trimmed non empty string')->toString();
+        $this->slug = TrimmedNonEmptyString::fromString($values['slug'], 'The value of the "slug" key must be a non-empty, trimmed string. Got: %s')->toString();
 
         Assert::keyExists($values, 'path');
 
         if (null !== $values['path'] && '' !== $values['path']) {
-            $path = TrimmedNonEmptyString::fromString($values['path'], 'The value of key "path" must be an trimmed non empty string')->toString();
+            $path = TrimmedNonEmptyString::fromString($values['path'], 'The value of the "path" key must be a non-empty, trimmed string. Got: %s')->toString();
         }
 
         $this->path = $path ?? null;
 
         Assert::keyExists($values, 'real_path');
-        $this->realPath = TrimmedNonEmptyString::fromString($values['real_path'], 'The value of key "real_path" must be an trimmed non empty string')->toString();
+        $this->realPath = TrimmedNonEmptyString::fromString($values['real_path'], 'The value of the "real_path" key must be a non-empty, trimmed string. Got: %s')->toString();
 
         Assert::keyExists($values, 'position');
-        Assert::integer($values['position']);
+        Assert::integer($values['position'], 'The value of the "position" key must be an integer. Got: %s');
         $this->position = $values['position'];
 
         Assert::keyExists($values, 'is_folder');
@@ -94,7 +94,7 @@ final readonly class Link
         $this->isPublished = true === $values['published'];
 
         Assert::keyExists($values, 'alternates');
-        Assert::isArray($values['alternates']);
+        Assert::isArray($values['alternates'], 'The value of the "alternates" key must be an array. Got: %s');
         $this->alternates = array_map(static fn (array $values) => new LinkAlternate($values), $values['alternates']);
     }
 

--- a/src/Domain/Value/Link.php
+++ b/src/Domain/Value/Link.php
@@ -72,7 +72,7 @@ final readonly class Link
         Assert::keyExists($values, 'path');
 
         if (null !== $values['path'] && '' !== $values['path']) {
-            $path = TrimmedNonEmptyString::fromString($values['path'], 'The value of key "path" is invalid.')->toString();
+            $path = TrimmedNonEmptyString::fromString($values['path'], 'The value of key "path" must be an trimmed non empty string')->toString();
         }
 
         $this->path = $path ?? null;

--- a/src/Domain/Value/Link.php
+++ b/src/Domain/Value/Link.php
@@ -72,7 +72,7 @@ final readonly class Link
         Assert::keyExists($values, 'path');
 
         if (null !== $values['path']) {
-            $path = TrimmedNonEmptyString::fromString($values['path'])->toString();
+            $path = TrimmedNonEmptyString::fromString($values['path'], 'The value of key "path" is invalid.')->toString();
         }
 
         $this->path = $path ?? null;

--- a/src/Domain/Value/Link.php
+++ b/src/Domain/Value/Link.php
@@ -71,7 +71,7 @@ final readonly class Link
 
         Assert::keyExists($values, 'path');
 
-        if (null !== $values['path']) {
+        if (null !== $values['path'] && '' !== $values['path']) {
             $path = TrimmedNonEmptyString::fromString($values['path'], 'The value of key "path" is invalid.')->toString();
         }
 

--- a/src/Domain/Value/Link.php
+++ b/src/Domain/Value/Link.php
@@ -64,10 +64,10 @@ final readonly class Link
         $this->uuid = new Uuid($values['uuid']);
 
         Assert::keyExists($values, 'name');
-        $this->name = TrimmedNonEmptyString::fromString($values['name'])->toString();
+        $this->name = TrimmedNonEmptyString::fromString($values['name'], 'The value of key "name" must be an trimmed non empty string')->toString();
 
         Assert::keyExists($values, 'slug');
-        $this->slug = TrimmedNonEmptyString::fromString($values['slug'])->toString();
+        $this->slug = TrimmedNonEmptyString::fromString($values['slug'], 'The value of key "slug" must be an trimmed non empty string')->toString();
 
         Assert::keyExists($values, 'path');
 
@@ -78,7 +78,7 @@ final readonly class Link
         $this->path = $path ?? null;
 
         Assert::keyExists($values, 'real_path');
-        $this->realPath = TrimmedNonEmptyString::fromString($values['real_path'])->toString();
+        $this->realPath = TrimmedNonEmptyString::fromString($values['real_path'], 'The value of key "real_path" must be an trimmed non empty string')->toString();
 
         Assert::keyExists($values, 'position');
         Assert::integer($values['position']);

--- a/tests/Unit/Domain/Value/LinkTest.php
+++ b/tests/Unit/Domain/Value/LinkTest.php
@@ -161,7 +161,7 @@ final class LinkTest extends TestCase
     {
         $values = self::faker()->linkResponse(['path' => $value]);
 
-        self::expectExceptionMessage('The value of key "path" must be an trimmed non empty string');
+        self::expectExceptionMessage('The value of the "path" key must be a non-empty, trimmed string. Got: ""');
         self::expectException(\InvalidArgumentException::class);
 
         new Link($values);

--- a/tests/Unit/Domain/Value/LinkTest.php
+++ b/tests/Unit/Domain/Value/LinkTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 
 namespace Storyblok\Api\Tests\Unit\Domain\Value;
 
+use Ergebnis\DataProvider\StringProvider;
+use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Storyblok\Api\Domain\Value\Link;
@@ -148,6 +150,19 @@ final class LinkTest extends TestCase
         $values = self::faker()->linkResponse();
         unset($values['path']);
 
+        self::expectException(\InvalidArgumentException::class);
+
+        new Link($values);
+    }
+
+    #[DataProviderExternal(StringProvider::class, 'blank')]
+    #[DataProviderExternal(StringProvider::class, 'empty')]
+    #[Test]
+    public function pathMustBeValidString(string $value): void
+    {
+        $values = self::faker()->linkResponse(['path' => $value]);
+
+        self::expectExceptionMessage('The value of key "path" is invalid.');
         self::expectException(\InvalidArgumentException::class);
 
         new Link($values);

--- a/tests/Unit/Domain/Value/LinkTest.php
+++ b/tests/Unit/Domain/Value/LinkTest.php
@@ -161,7 +161,7 @@ final class LinkTest extends TestCase
     {
         $values = self::faker()->linkResponse(['path' => $value]);
 
-        self::expectExceptionMessage('The value of key "path" is invalid.');
+        self::expectExceptionMessage('The value of key "path" must be an trimmed non empty string');
         self::expectException(\InvalidArgumentException::class);
 
         new Link($values);

--- a/tests/Unit/Domain/Value/LinkTest.php
+++ b/tests/Unit/Domain/Value/LinkTest.php
@@ -156,7 +156,6 @@ final class LinkTest extends TestCase
     }
 
     #[DataProviderExternal(StringProvider::class, 'blank')]
-    #[DataProviderExternal(StringProvider::class, 'empty')]
     #[Test]
     public function pathMustBeValidString(string $value): void
     {


### PR DESCRIPTION
### TL;DR

> [!NOTE]
> I encountered a strange bug related to a Story in Storyblok. This PR might help identify the root cause.

### Long Version

In the Storyblok API responses (both Management API and Content Delivery API), the `path` value was returned as an empty string (`""`) instead of `null`.Running the following command resulted in an error:

```bash
symfony console registries:setup
```

Which produced:

```
In Assert.php line 2074:

Expected a different value than "".

```

As a result, many links were missing in the `LinkRegistry`, which is part of the [`storyblok/symfony-bundle`](https://github.com/storyblok/symfony-bundle/).

### How to Fix This in Storyblok

Review the Content Delivery API response from [Retrieve Multiple Links](https://www.storyblok.com/docs/api/content-delivery/v2/links/retrieve-multiple-links), for example:

```
https://api.storyblok.com/v2/cdn/links/?version=draft&token={YOUR_TOKEN}&per_page=1000
```

Look for entries where `"path": ""` (the expected default is `"path": null`).Delete and recreate the affected stories in the Storyblok editor.

### Final Note

I'm not sure whether this bug is easily reproducible in Storyblok — and I didn’t want to risk reproducing it in a production environment.
For context: the affected story had its `first_published_at` value changed, and multi-language support was enabled.


