### PR TITLE
fix: Always add `paginated` parameter for older spaces

### DIFF
--- a/src/LinksApi.php
+++ b/src/LinksApi.php
@@ -46,6 +46,7 @@ final class LinksApi implements LinksApiInterface
         $response = $this->client->request('GET', self::ENDPOINT, [
             'query' => [
                 ...$request->toArray(),
+                'paginated' => 1,
                 'version' => null !== $request->version ? $request->version->value : $this->version->value,
             ],
         ]);
@@ -65,6 +66,7 @@ final class LinksApi implements LinksApiInterface
             'query' => [
                 ...$request->toArray(),
                 'with_parent' => $parentId->value,
+                'paginated' => 1,
                 'version' => null !== $request->version ? $request->version->value : $this->version->value,
             ],
         ]);
@@ -84,6 +86,7 @@ final class LinksApi implements LinksApiInterface
             'query' => [
                 ...$request->toArray(),
                 'with_parent' => 0,
+                'paginated' => 1,
                 'version' => null !== $request->version ? $request->version->value : $this->version->value,
             ],
         ]);


### PR DESCRIPTION
This is due to https://www.storyblok.com/docs/api/content-delivery/v2/links/retrieve-multiple-links:

For spaces created before May 9th, 2023, the links endpoint is not paginated by default. To enable pagination, set the paginated parameter to 1.

