### PR TITLE
Add Missing Parameters to Stories Content API

### DIFF
--- a/src/Domain/Value/Dto/StoryLevel.php
+++ b/src/Domain/Value/Dto/StoryLevel.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/php-content-api-client.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Domain\Value\Dto;
+
+/**
+ * @author Phil Betley <jpbetley@gmail.com>
+ *
+ * @see https://www.storyblok.com/docs/api/content-delivery/v2/stories/retrieve-multiple-stories
+ */
+enum StoryLevel: int
+{
+    case Root = 1;
+    case TopLevel = 2;
+    case SecondLevel = 3;
+}

--- a/src/Request/StoriesRequest.php
+++ b/src/Request/StoriesRequest.php
@@ -16,6 +16,7 @@ namespace Storyblok\Api\Request;
 
 use Storyblok\Api\Domain\Value\Dto\Pagination;
 use Storyblok\Api\Domain\Value\Dto\SortBy;
+use Storyblok\Api\Domain\Value\Dto\StoryLevel;
 use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Field\FieldCollection;
 use Storyblok\Api\Domain\Value\Filter\FilterCollection;
@@ -62,6 +63,8 @@ final readonly class StoriesRequest
         public ?UpdatedAtGt $updatedAtGt = null,
         public ?UpdatedAtLt $updatedAtLt = null,
         public SlugCollection $bySlugs = new SlugCollection(),
+        public ?StoryLevel $level = null,
+        public ?bool $isStartpage = null,
     ) {
         Assert::stringNotEmpty($language);
         Assert::lessThanEq($this->pagination->perPage, self::MAX_PER_PAGE);
@@ -90,6 +93,8 @@ final readonly class StoriesRequest
      *     first_published_at_lt?: string,
      *     updated_at_gt?: string,
      *     updated_at_lt?: string,
+     *     level?: int,
+     *     is_startpage?: bool,
      * }
      */
     public function toArray(): array
@@ -171,6 +176,14 @@ final readonly class StoriesRequest
 
         if ($this->bySlugs->count() > 0) {
             $array['by_slugs'] = $this->bySlugs->toString();
+        }
+
+        if (null !== $this->level) {
+            $array['level'] = $this->level->value;
+        }
+
+        if (null !== $this->isStartpage) {
+            $array['is_startpage'] = $this->isStartpage ? 1 : 0;
         }
 
         return $array;

--- a/tests/Unit/Request/StoriesRequestTest.php
+++ b/tests/Unit/Request/StoriesRequestTest.php
@@ -14,10 +14,12 @@ declare(strict_types=1);
 
 namespace Storyblok\Api\Tests\Unit\Request;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Storyblok\Api\Domain\Value\Dto\Direction;
 use Storyblok\Api\Domain\Value\Dto\SortBy;
+use Storyblok\Api\Domain\Value\Dto\StoryLevel;
 use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Field\Field;
 use Storyblok\Api\Domain\Value\Field\FieldCollection;
@@ -365,5 +367,60 @@ final class StoriesRequestTest extends TestCase
             'per_page' => 25,
             'by_slugs' => 'path/*,another-path/*',
         ], $request->toArray());
+    }
+
+
+    #[DataProvider('levelProvider')]
+    #[Test]
+    public function toArrayLevel(StoryLevel $level, int $expected): void
+    {
+        $request = new StoriesRequest(
+            level: $level,
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'level' => $expected,
+        ], $request->toArray());
+    }
+
+
+    /**
+     * @return iterable<string, array{0: StoryLevel, 1: int}>
+     */
+    public static function levelProvider(): iterable
+    {
+        yield 'root' => [StoryLevel::Root, 1];
+        yield 'top-level' => [StoryLevel::TopLevel, 2];
+        yield 'second-level' => [StoryLevel::SecondLevel, 3];
+    }
+
+
+    #[DataProvider('isStartpageProvider')]
+    #[Test]
+    public function toArrayIsStartpage(bool $isStartpage, int $expected): void
+    {
+        $request = new StoriesRequest(
+            isStartpage: $isStartpage,
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'is_startpage' => $expected,
+        ], $request->toArray());
+    }
+
+
+    /**
+     * @return iterable<string, array{0: bool, 1: int}>
+     */
+    public static function isStartpageProvider(): iterable
+    {
+        yield 'true' => [true, 1];
+        yield 'false' => [false, 0];
     }
 }


### PR DESCRIPTION
## Purpose
This PR adds support for the missing `level` and `is_startpage` request parameters for the Stories CDN API endpoint

## Description
- Adds `StoryLevel` enum DTO for selecting the appropriate level parameter to use in the request
- Adds `$level` and `$isStartpage` optional parameters to the `StoriesRequest` constructor
- Updates the `StoriesRequest::toArray` method to add the `level` and `is_startpage` values to the resulting array if they have been configured for the request
- Adds tests with data providers for all expected values for both the `$level` and `$isStartpage` query parameters