### PR TITLE
Add fallback_lang parameter to StoryRequest and StoriesRequest

### DIFF
--- a/src/Request/StoriesRequest.php
+++ b/src/Request/StoriesRequest.php
@@ -65,6 +65,7 @@ final readonly class StoriesRequest
         public SlugCollection $bySlugs = new SlugCollection(),
         public ?StoryLevel $level = null,
         public ?bool $isStartpage = null,
+        public ?string $fallbackLanguage = null,
     ) {
         Assert::stringNotEmpty($language);
         Assert::lessThanEq($this->pagination->perPage, self::MAX_PER_PAGE);
@@ -95,6 +96,7 @@ final readonly class StoriesRequest
      *     updated_at_lt?: string,
      *     level?: int,
      *     is_startpage?: bool,
+     *     fallback_lang?: string,
      * }
      */
     public function toArray(): array
@@ -184,6 +186,10 @@ final readonly class StoriesRequest
 
         if (null !== $this->isStartpage) {
             $array['is_startpage'] = $this->isStartpage ? 1 : 0;
+        }
+
+        if (null !== $this->fallbackLanguage) {
+            $array['fallback_lang'] = $this->fallbackLanguage;
         }
 
         return $array;

--- a/src/Request/StoryRequest.php
+++ b/src/Request/StoryRequest.php
@@ -29,6 +29,7 @@ final readonly class StoryRequest
         public ?Version $version = null,
         public RelationCollection $withRelations = new RelationCollection(),
         public ResolveLinks $resolveLinks = new ResolveLinks(),
+        public ?string $fallbackLanguage = null,
     ) {
         Assert::stringNotEmpty($language);
     }
@@ -40,6 +41,7 @@ final readonly class StoryRequest
      *     resolve_relations?: string,
      *     resolve_links?: string,
      *     resolve_links_level?: int,
+     *     fallback_lang?: string,
      * }
      */
     public function toArray(): array
@@ -59,6 +61,10 @@ final readonly class StoryRequest
         if (null !== $this->resolveLinks->type) {
             $array['resolve_links'] = $this->resolveLinks->type->value;
             $array['resolve_links_level'] = $this->resolveLinks->level->value;
+        }
+
+        if (null !== $this->fallbackLanguage) {
+            $array['fallback_lang'] = $this->fallbackLanguage;
         }
 
         return $array;


### PR DESCRIPTION
Adds an optional fallbackLanguage constructor parameter to both StoryRequest and StoriesRequest. When set, the Storyblok Content Delivery API parameter fallback_lang is included in the query, enabling field-level fallback for untranslated content.