### PR TITLE
Allow filtering Stories by content_type

### DIFF
--- a/src/Request/StoriesRequest.php
+++ b/src/Request/StoriesRequest.php
@@ -65,6 +65,7 @@ final readonly class StoriesRequest
         public SlugCollection $bySlugs = new SlugCollection(),
         public ?StoryLevel $level = null,
         public ?bool $isStartpage = null,
+        public ?string $contentType = null,
     ) {
         Assert::stringNotEmpty($language);
         Assert::lessThanEq($this->pagination->perPage, self::MAX_PER_PAGE);
@@ -95,6 +96,7 @@ final readonly class StoriesRequest
      *     updated_at_lt?: string,
      *     level?: int,
      *     is_startpage?: bool,
+     *     content_type?: string,
      * }
      */
     public function toArray(): array
@@ -184,6 +186,10 @@ final readonly class StoriesRequest
 
         if (null !== $this->isStartpage) {
             $array['is_startpage'] = $this->isStartpage ? 1 : 0;
+        }
+
+        if (null !== $this->contentType) {
+            $array['content_type'] = $this->contentType;
         }
 
         return $array;

--- a/tests/Unit/Request/StoriesRequestTest.php
+++ b/tests/Unit/Request/StoriesRequestTest.php
@@ -370,6 +370,22 @@ final class StoriesRequestTest extends TestCase
     }
 
 
+    #[Test]
+    public function toArrayWithContentType(): void
+    {
+        $request = new StoriesRequest(
+            contentType: 'article',
+        );
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'content_type' => 'article',
+        ], $request->toArray());
+    }
+
+
     #[DataProvider('levelProvider')]
     #[Test]
     public function toArrayLevel(StoryLevel $level, int $expected): void
@@ -387,17 +403,6 @@ final class StoriesRequestTest extends TestCase
     }
 
 
-    /**
-     * @return iterable<string, array{0: StoryLevel, 1: int}>
-     */
-    public static function levelProvider(): iterable
-    {
-        yield 'root' => [StoryLevel::Root, 1];
-        yield 'top-level' => [StoryLevel::TopLevel, 2];
-        yield 'second-level' => [StoryLevel::SecondLevel, 3];
-    }
-
-
     #[DataProvider('isStartpageProvider')]
     #[Test]
     public function toArrayIsStartpage(bool $isStartpage, int $expected): void
@@ -412,6 +417,17 @@ final class StoriesRequestTest extends TestCase
             'per_page' => 25,
             'is_startpage' => $expected,
         ], $request->toArray());
+    }
+
+
+    /**
+     * @return iterable<string, array{0: StoryLevel, 1: int}>
+     */
+    public static function levelProvider(): iterable
+    {
+        yield 'root' => [StoryLevel::Root, 1];
+        yield 'top-level' => [StoryLevel::TopLevel, 2];
+        yield 'second-level' => [StoryLevel::SecondLevel, 3];
     }
 
 


### PR DESCRIPTION
Added support for filtering the stories request by content_type, see: https://www.storyblok.com/docs/api/content-delivery/v2/stories/retrieve-multiple-stories