### PR TITLE
add advanced sort_by support

### DIFF
--- a/src/Domain/Value/Dto/SortBy.php
+++ b/src/Domain/Value/Dto/SortBy.php
@@ -24,12 +24,19 @@ final readonly class SortBy
     public function __construct(
         public string $field,
         public Direction $direction,
+        public ?SortByDataType $dataType = null,
+        public ?SortByNulls $nulls = null,
     ) {
         TrimmedNonEmptyString::fromString($field);
     }
 
     public function toString(): string
     {
-        return \sprintf('%s:%s', $this->field, $this->direction->value);
+        return implode(':', array_filter([
+            $this->field,
+            $this->direction->value,
+            $this->dataType?->value,
+            $this->nulls?->value,
+        ]));
     }
 }

--- a/src/Domain/Value/Dto/SortByCollection.php
+++ b/src/Domain/Value/Dto/SortByCollection.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/php-content-api-client.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Domain\Value\Dto;
+
+/**
+ * @implements \IteratorAggregate<int, SortBy>
+ */
+final class SortByCollection implements \Countable, \IteratorAggregate
+{
+    /**
+     * @var list<SortBy>
+     */
+    private array $items = [];
+
+    /**
+     * @param list<SortBy> $items
+     */
+    public function __construct(array $items = [])
+    {
+        foreach ($items as $item) {
+            $this->add($item);
+        }
+    }
+
+    /**
+     * @return \Traversable<int, SortBy>
+     */
+    public function getIterator(): \Traversable
+    {
+        return new \ArrayIterator($this->items);
+    }
+
+    public function count(): int
+    {
+        return \count($this->items);
+    }
+
+    public function add(SortBy $sortBy): void
+    {
+        $this->items[] = $sortBy;
+    }
+
+    public function toString(): string
+    {
+        return implode(',', array_map(static fn (SortBy $sortBy): string => $sortBy->toString(), $this->items));
+    }
+}

--- a/src/Domain/Value/Dto/SortByDataType.php
+++ b/src/Domain/Value/Dto/SortByDataType.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/php-content-api-client.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Domain\Value\Dto;
+
+enum SortByDataType: string
+{
+    case Float = 'float';
+    case Int = 'int';
+}

--- a/src/Domain/Value/Dto/SortByNulls.php
+++ b/src/Domain/Value/Dto/SortByNulls.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/php-content-api-client.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Domain\Value\Dto;
+
+enum SortByNulls: string
+{
+    case First = 'nulls_first';
+    case Last = 'nulls_last';
+}

--- a/src/Request/StoriesRequest.php
+++ b/src/Request/StoriesRequest.php
@@ -16,6 +16,7 @@ namespace Storyblok\Api\Request;
 
 use Storyblok\Api\Domain\Value\Dto\Pagination;
 use Storyblok\Api\Domain\Value\Dto\SortBy;
+use Storyblok\Api\Domain\Value\Dto\SortByCollection;
 use Storyblok\Api\Domain\Value\Dto\StoryLevel;
 use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Field\FieldCollection;
@@ -45,7 +46,7 @@ final readonly class StoriesRequest
     public function __construct(
         public string $language = 'default',
         public Pagination $pagination = new Pagination(perPage: self::PER_PAGE),
-        public ?SortBy $sortBy = null,
+        public null|SortBy|SortByCollection $sortBy = null,
         public FilterCollection $filters = new FilterCollection(),
         public FieldCollection $excludeFields = new FieldCollection(),
         public TagCollection $withTags = new TagCollection(),
@@ -107,7 +108,11 @@ final readonly class StoriesRequest
             'per_page' => $this->pagination->perPage,
         ];
 
-        if (null !== $this->sortBy) {
+        if ($this->sortBy instanceof SortBy) {
+            $array['sort_by'] = $this->sortBy->toString();
+        }
+
+        if ($this->sortBy instanceof SortByCollection && $this->sortBy->count() > 0) {
             $array['sort_by'] = $this->sortBy->toString();
         }
 

--- a/tests/Unit/Domain/Value/Dto/SortByCollectionTest.php
+++ b/tests/Unit/Domain/Value/Dto/SortByCollectionTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * This file is part of storyblok/php-content-api-client.
+ *
+ * (c) Storyblok GmbH <info@storyblok.com>
+ * in cooperation with SensioLabs Deutschland <info@sensiolabs.de>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Storyblok\Api\Tests\Unit\Domain\Value\Dto;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Storyblok\Api\Domain\Value\Dto\Direction;
+use Storyblok\Api\Domain\Value\Dto\SortBy;
+use Storyblok\Api\Domain\Value\Dto\SortByCollection;
+
+final class SortByCollectionTest extends TestCase
+{
+    #[Test]
+    public function toStringMethod(): void
+    {
+        $collection = new SortByCollection([
+            new SortBy('name', Direction::Desc),
+            new SortBy('slug', Direction::Asc),
+        ]);
+
+        self::assertSame('name:desc,slug:asc', $collection->toString());
+    }
+}

--- a/tests/Unit/Domain/Value/Dto/SortByTest.php
+++ b/tests/Unit/Domain/Value/Dto/SortByTest.php
@@ -20,6 +20,8 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Storyblok\Api\Domain\Value\Dto\Direction;
 use Storyblok\Api\Domain\Value\Dto\SortBy;
+use Storyblok\Api\Domain\Value\Dto\SortByDataType;
+use Storyblok\Api\Domain\Value\Dto\SortByNulls;
 use Storyblok\Api\Tests\Util\FakerTrait;
 
 /**
@@ -53,5 +55,32 @@ final class SortByTest extends TestCase
         $value = self::faker()->word();
 
         self::assertSame(\sprintf('%s:%s', $value, Direction::Asc->value), (new SortBy($value, Direction::Asc))->toString());
+    }
+
+    #[Test]
+    public function toStringMethodWithDataType(): void
+    {
+        self::assertSame(
+            'content.price:asc:float',
+            (new SortBy('content.price', Direction::Asc, SortByDataType::Float))->toString(),
+        );
+    }
+
+    #[Test]
+    public function toStringMethodWithNullHandling(): void
+    {
+        self::assertSame(
+            'path:desc:nulls_first',
+            (new SortBy('path', Direction::Desc, null, SortByNulls::First))->toString(),
+        );
+    }
+
+    #[Test]
+    public function toStringMethodWithDataTypeAndNullHandling(): void
+    {
+        self::assertSame(
+            'content.event_number:desc:int:nulls_last',
+            (new SortBy('content.event_number', Direction::Desc, SortByDataType::Int, SortByNulls::Last))->toString(),
+        );
     }
 }

--- a/tests/Unit/Request/StoriesRequestTest.php
+++ b/tests/Unit/Request/StoriesRequestTest.php
@@ -19,6 +19,9 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Storyblok\Api\Domain\Value\Dto\Direction;
 use Storyblok\Api\Domain\Value\Dto\SortBy;
+use Storyblok\Api\Domain\Value\Dto\SortByCollection;
+use Storyblok\Api\Domain\Value\Dto\SortByDataType;
+use Storyblok\Api\Domain\Value\Dto\SortByNulls;
 use Storyblok\Api\Domain\Value\Dto\StoryLevel;
 use Storyblok\Api\Domain\Value\Dto\Version;
 use Storyblok\Api\Domain\Value\Field\Field;
@@ -74,6 +77,35 @@ final class StoriesRequestTest extends TestCase
             'page' => 1,
             'per_page' => 25,
             'sort_by' => 'name:asc',
+        ], $request->toArray());
+    }
+
+    #[Test]
+    public function toArrayWithAdvancedSortBy(): void
+    {
+        $request = new StoriesRequest(sortBy: new SortBy('content.price', Direction::Asc, SortByDataType::Float, SortByNulls::Last));
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'sort_by' => 'content.price:asc:float:nulls_last',
+        ], $request->toArray());
+    }
+
+    #[Test]
+    public function toArrayWithSortByCollection(): void
+    {
+        $request = new StoriesRequest(sortBy: new SortByCollection([
+            new SortBy('name', Direction::Desc),
+            new SortBy('slug', Direction::Asc),
+        ]),);
+
+        self::assertSame([
+            'language' => 'default',
+            'page' => 1,
+            'per_page' => 25,
+            'sort_by' => 'name:desc,slug:asc',
         ], $request->toArray());
     }
 


### PR DESCRIPTION
## Summary

This PR extends sort_by support in the Content API client so the SDK can represent the full Storyblok sorting syntax
used by the Content Delivery API.

It adds support for:

- single sort definitions via `SortBy`
- chained comma-separated sorts via `SortByCollection`
- numeric sort modifiers via `:float and `:int`
- null handling via `:nulls_first` and `:nulls_last`

Storyblok supports richer `sort_by` expressions than the SDK could previously express. In particular, the actual
implementation could not model:

- chained sorts like `name:desc,slug:asc`
- numeric modifiers like `content.price:asc:float`
- null ordering like `path:desc:nulls_first`

This PR brings the SDK in line with the documented API behavior.

`StoriesRequest` now accepts:

```php
public SortBy|SortByCollection|null $sortBy = null
```

This keeps the API compact and breaking-change-free while allowing both simple and advanced sorting scenarios.

## What Changed

- `SortBy` was extended to support:
    - field
    - direction
    - optional dataType
    - optional nulls

- Added new enums:
    - `SortByDataType`
    - `SortByNulls`

- Added `SortByCollection` to represent multiple sort definitions
- Updated StoriesRequest::toArray() so sort_by is generated from either:
    - a single SortBy
    - or a SortByCollection

## Examples

### Simple default property sorting

```php
new StoriesRequest(
    sortBy: new SortBy('created_at', Direction::Desc),
);
```

Results into

```
created_at:desc
```

### Numeric sorting

```php
new StoriesRequest(
    sortBy: new SortBy('content.price', Direction::Asc, SortByDataType::Float),
);
new StoriesRequest(
    sortBy: new SortBy('content.price', Direction::Asc, SortByDataType::Int),
);
```

Results into

```
content.price:asc:float
content.price:asc:int
```

### Null handling:

```php
new StoriesRequest(
    sortBy: new SortBy('path', Direction::Desc, null, SortByNulls::First),
);

new StoriesRequest(
    sortBy: new SortBy('path', Direction::Desc, null, SortByNulls::Last),
);
```

Results into

```
path:desc:nulls_first
path:desc:nulls_last
```

### Multiple sorts:

```php
new StoriesRequest(
    sortBy: new SortByCollection([
        new SortBy('name', Direction::Desc),
        new SortBy('slug', Direction::Asc),
    ]),
);
```

Results into

```
name:desc,slug:asc
```

### Combined advanced sorts

```php
$request = new StoriesRequest(
    sortBy: new SortByCollection([
        new SortBy('first_published_at', Direction::Desc, null, SortByNulls::Last),
        new SortBy('published_at', Direction::Desc, null, SortByNulls::Last),
        new SortBy('created_at', Direction::Desc),
    ]),
);
``````

Results into

```
first_published_at:desc:nulls_last,published_at:desc:nulls_last,created_at:desc
```

Tests

Added/updated unit tests for:

- `SortBy`
- `SortByCollection`
- `StoriesRequest`

Verified cases include:

- simple sorting
- advanced sorting with data type modifiers
- null ordering
- chained sorting serialization through StoriesRequest::toArray()

I didn't adjust the existing tests, because the changes are no breaking changes, so all other test still passes.